### PR TITLE
Rename files to make python -m seedir work

### DIFF
--- a/seedir/__main__.py
+++ b/seedir/__main__.py
@@ -4,7 +4,7 @@
 import argparse
 import os
 
-import seedir as sd
+from .realdir import seedir
 
 helptxt = """
 Help for the seedir CLI.  Function for printing a folder tree
@@ -100,7 +100,7 @@ def main():
 
     kwargs = vars(args)
     del kwargs['help']
-    sd.seedir(**kwargs)
+    seedir(**kwargs)
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(name='seedir',
       long_description=long_description,
       long_description_content_type='text/markdown',
       entry_points = {
-        'console_scripts': ['seedir=seedir.command_line:main'],
+        'console_scripts': ['seedir=seedir.__main__:main'],
         })


### PR DESCRIPTION
Closes #22 

```bash
Bruin056@UU083226 seedir % python -m seedir                                     
seedir/
├─LICENSE
├─.pytest_cache/
│ ├─CACHEDIR.TAG
│ ├─README.md
│ ├─.gitignore
│ └─v/
│   └─cache/
│     ├─nodeids
│     └─stepwise
├─CHANGELOG.md
├─tests/
│ ├─__init__.py
│ ├─__pycache__/
│ │ ├─__init__.cpython-39.pyc
│ │ └─tests.cpython-39.pyc
│ └─tests.py

```